### PR TITLE
Width height

### DIFF
--- a/width-height.html
+++ b/width-height.html
@@ -6,17 +6,14 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    .parent {
-      width: 100px;
-    }
-    p {
-      background: orange;
+    .example img {
+      width: 50px;
     }
   </style>
 </head>
 <body>
-<div class="parent">
-  <p>これは要素です。</p>
-</div>
+<p class="example">
+  <img src="https://saruwakakun.com/wp-content/uploads/2016/11/IMG_9164.jpeg" alt="さるわかくんの顔" />
+</p>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -15,8 +15,10 @@
       background: yellow;
     }
     .parent p {
-      width: 50%;
+      width: 100%;
+      padding: 20px;
       background: orange;
+      box-sizing: border-box;
     }
   </style>
 </head>

--- a/width-height.html
+++ b/width-height.html
@@ -6,16 +6,31 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    #test {
+    #test1 {
+      background: gray;
+    }
+
+    #test2 {
+      background: gray;
+      height: 100px;
+    }
+
+    #test1 > p,
+    #test2 > p {
+      height: 50%;
       background: orange;
-      height: 50px;
     }
   </style>
 </head>
 <body>
-<div id="test">
-  <p>子要素です。</p>
-  <p><img src="https://saruwakakun.com/wp-content/uploads/2016/11/IMG_9164.jpeg" alt="さるわかくんの顔" /></p>
+<p>親のheightが未指定</p>
+<div id="test1">
+  <p>要素</p>
+</div>
+
+<p>親のheightが指定</p>
+<div id="test2">
+  <p>要素</p>
 </div>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -6,31 +6,18 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    #test1 {
-      background: gray;
+    html, body {
+      height: 100%;
     }
-
-    #test2 {
-      background: gray;
-      height: 100px;
-    }
-
-    #test1 > p,
-    #test2 > p {
+    #headline {
       height: 50%;
       background: orange;
     }
   </style>
 </head>
 <body>
-<p>親のheightが未指定</p>
-<div id="test1">
-  <p>要素</p>
-</div>
-
-<p>親のheightが指定</p>
-<div id="test2">
-  <p>要素</p>
+<div id="headline">
+  <p>これは例文です</p>
 </div>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -6,14 +6,17 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    p {
+    .parent {
       width: 100px;
-      height: 100px;
+    }
+    p {
       background: orange;
     }
   </style>
 </head>
 <body>
-<p>これは例文です。</p>
+<div class="parent">
+  <p>これは要素です。</p>
+</div>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -1,0 +1,19 @@
+<!-- ref: https://saruwakakun.com/html-css/basic/width-height -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+  <style>
+    p {
+      width: 100px;
+      height: 100px;
+      background: orange;
+    }
+  </style>
+</head>
+<body>
+<p>これは例文です。</p>
+</body>
+</html>

--- a/width-height.html
+++ b/width-height.html
@@ -6,14 +6,25 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    .example img {
-      width: 50px;
+    .grandpa {
+      width: 200px;
+      background: silver;
+    }
+    .parent {
+      width: 50%;
+      background: yellow;
+    }
+    .parent p {
+      width: 50%;
+      background: orange;
     }
   </style>
 </head>
 <body>
-<p class="example">
-  <img src="https://saruwakakun.com/wp-content/uploads/2016/11/IMG_9164.jpeg" alt="さるわかくんの顔" />
-</p>
+<div class="grandpa">
+  <div class="parent">
+    <p>これは要素です</p>
+  </div>
+</div>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -6,27 +6,15 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
-    .grandpa {
-      width: 200px;
-      background: silver;
-    }
-    .parent {
-      width: 50%;
-      background: yellow;
-    }
-    .parent p {
-      width: 100%;
-      padding: 20px;
+    #test {
       background: orange;
-      box-sizing: border-box;
     }
   </style>
 </head>
 <body>
-<div class="grandpa">
-  <div class="parent">
-    <p>これは要素です</p>
-  </div>
+<div id="test">
+  <p>子要素です。</p>
+  <p><img src="https://saruwakakun.com/wp-content/uploads/2016/11/IMG_9164.jpeg" alt="さるわかくんの顔" /></p>
 </div>
 </body>
 </html>

--- a/width-height.html
+++ b/width-height.html
@@ -8,6 +8,7 @@
   <style>
     #test {
       background: orange;
+      height: 50px;
     }
   </style>
 </head>


### PR DESCRIPTION
## widthの設定方法
- `width: auto;` 
  - 初期値
  - 値を自動的に決める (要素の幅と同じなる。ただし、親要素以上に大きくなることはない)
- `width: XXpx`
  - pxによる絶対値の指定
  - 画像に指定すると、画像の幅を調整することができる (画像の高さも初期値がautoなので、widthに合わせて縦横比を保ってくれる)
  - 親要素の幅 > 子要素の幅 にしてはいけない (子要素がはみ出た見た目になってしまう)

- `width: XX%`
  - 要素の幅が可変になる (親要素の幅に対する比率で決まる)
  - 親要素の幅が指定されていない場合は親を遡っていく
    - body要素まで指定されていない場合は、ブラウザの幅になる

### `width: auto;`と`width: 100%;`の違い
- autoは、widthの中にpaddingとborderが含まれるようになる (`box-sizing: border-box;`の状態)
- 100%は、paddingとborderを含まない
  - 100%の要素に、paddingやborderが含まれていると親要素からはみ出してしまう
  - 対策として、`box-sizing: border-box;`を指定するなどがある

### inline-blockの場合に横いっぱいに広げる
- width: 100%に指定する必要がある
- inline-blockの要素の幅の初期値は、要素の中身の幅になる。横いっぱいにするには明示的に100%と書かなければならない


## heightの設定方法
- `height: auto;`
  - 初期値
  - 要素(文字・画像・子要素など)の中身の分だけの高さになる


- `height: XXpx`
  - pxによる絶対値の指定
  - 親要素の高さ > 子要素の高さ にしてはいけない (子要素がはみ出た見た目になってしまう)

- `height: XX%`
  - 要素の高さが可変になる (親要素の高さに対する比率で決まる)
  - widthと違って、親要素のheightが指定されていない(= autoの状態)と、%指定はできない (親要素と重なった状態で表示されるため)
    - 実際に高さを%で指定することはほとんどない

### 画面全体の高さに対して、比率で高さを指定する
- htmlとbodyタグ、親要素に対してheight:100%と指定した上で、該当の要素に%指定する