### PR TITLE
Box shadow

### DIFF
--- a/box-shadow.html
+++ b/box-shadow.html
@@ -10,7 +10,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 2px 2px 4px gray;
+      box-shadow: 10px 10px 15px -10px;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -6,11 +6,14 @@
   <meta charset="UTF-8">
   <title>Title</title>
   <style>
+    body {
+      margin: 20px;
+    }
     .example {
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 10px 10px 15px -10px;
+      box-shadow: 5px 5px 5px 10px rgba(0, 0, 0, 0.2);
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -10,7 +10,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: -4px -6px;
+      box-shadow: 6px 6px #668ad8;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -10,7 +10,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 4px 4px;
+      box-shadow: -4px -6px;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -10,7 +10,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 6px 6px #668ad8;
+      box-shadow: 2px 2px 4px gray;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -13,7 +13,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 5px 5px 5px 10px rgba(0, 0, 0, 0.2);
+      box-shadow: 2px 2px inset;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -11,17 +11,17 @@
     }
   </style>
   <style>
-    .sample {
-      padding: 20px;
-      margin: 2em;
-      max-width: 400px;
-      background: #fff;
-      border-radius: 3px;
-      box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+    header {
+      position: relative;
+      box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+      padding: 17px;
+      color: #fff;
+      font-weight: bold;
+      background: #4293f5;
     }
   </style>
 </head>
 <body>
-<div class="sample">これは例文です</div>
+<header>Header</header>
 </body>
 </html>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -1,0 +1,20 @@
+<!-- ref: https://saruwakakun.com/html-css/basic/box-shadow -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+  <style>
+    .example {
+      width: 100px;
+      height: 100px;
+      background-color: skyblue;
+      box-shadow: 4px 4px;
+    }
+  </style>
+</head>
+<body>
+<div class="example"></div>
+</body>
+</html>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -13,7 +13,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: 2px 2px inset;
+      box-shadow: -5px -5px 10px #668ad8 inset;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -16,12 +16,12 @@
       padding: 5px 10px;
       color: #fff;
       text-decoration: none;
-      background: skyblue;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      background: #eb8787;
+      box-shadow: 3px 3px #ffbe75;
       transition: .3s;
     }
     .sample:hover {
-      box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+      box-shadow: 1px 1px #ffbe75;
     }
   </style>
 </head>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -9,15 +9,23 @@
     body {
       margin: 20px;
     }
-    .example {
-      width: 100px;
-      height: 100px;
-      background-color: skyblue;
-      box-shadow: 3px 3px 6px -2px #555, 3px 3px 8px rgba(255, 255, 255, 0.8) inset;
+  </style>
+  <style>
+    .sample {
+      display: inline-block;
+      padding: 5px 10px;
+      color: #fff;
+      text-decoration: none;
+      background: skyblue;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      transition: .3s;
+    }
+    .sample:hover {
+      box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
     }
   </style>
 </head>
 <body>
-<div class="example"></div>
+<a class="sample" href="#">BUTTON</a>
 </body>
 </html>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -12,20 +12,16 @@
   </style>
   <style>
     .sample {
-      display: inline-block;
-      padding: 5px 10px;
-      color: #fff;
-      text-decoration: none;
-      background: #eb8787;
-      box-shadow: 3px 3px #ffbe75;
-      transition: .3s;
-    }
-    .sample:hover {
-      box-shadow: 1px 1px #ffbe75;
+      padding: 20px;
+      margin: 2em;
+      max-width: 400px;
+      background: #fff;
+      border-radius: 3px;
+      box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
     }
   </style>
 </head>
 <body>
-<a class="sample" href="#">BUTTON</a>
+<div class="sample">これは例文です</div>
 </body>
 </html>

--- a/box-shadow.html
+++ b/box-shadow.html
@@ -13,7 +13,7 @@
       width: 100px;
       height: 100px;
       background-color: skyblue;
-      box-shadow: -5px -5px 10px #668ad8 inset;
+      box-shadow: 3px 3px 6px -2px #555, 3px 3px 8px rgba(255, 255, 255, 0.8) inset;
     }
   </style>
 </head>


### PR DESCRIPTION
## box-shadow
- 何かの要素に影をつけたい時に使う
- 指定方法は、`box-shadow: 左右の向きpx 上下の向きpx ぼかしpx 広がりpx 色 内側指定;`
  - `左右の向きpx 上下の向きpx`は必須
  - 正の数だと、右方向・下方向に伸びる (左方向・上方向に伸ばしたい場合は負の数を指定する)
  - 0を指定すると、全体に広がる感じになる

### box-shadowのオプション
- 左右の向き 上下の向きを指定した後に、スペースを入れて入力する
  - 色を指定すれば、影の色を指定できる (ぼかしpxなどが必要な訳ではない。e.g. `box-shadow: 6px 6px #668ad8;`)
  - 全体をぼかすには、向きの指定に0を使う (e.g. `box-shadow: 0 0 8px gray;`)
  - 広がりpxを指定することで作った影を縮小・拡大できる (e.g. `box-shadow: 10px 10px 15px -10px;`)
  - 内側に影を付ける場合は、`inset`を指定する (e.g. `box-shadow: 2px 2px inset;`)
  - 複数の影を指定するには`,`で区切る (e.g. `box-shadow: 3px 3px 6px -2px #555, 3px 3px 8px rgba(255, 255, 255, 0.8) inset;`)

### テクニック
- 影の色を薄くするために、 `rgba()`を使ってalpha値を小さい値(0.2とか)にするといい感じになる